### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Download the latest `preprocess` zip source package, unzip it, and run `python
 setup.py install`:
 ```
     unzip master.zip
-    cd preprocess
+    cd preprocess-master
     python setup.py install
 ```
 Note that `preprocess.py` version 1.2 depends on [python-future](http://python-future.org). If you have `pip` installed, `python-future` is easily installed by

--- a/README.md
+++ b/README.md
@@ -162,8 +162,7 @@ Download the latest `preprocess` zip source package, unzip it, and run `python
 setup.py install`:
 ```
     unzip master.zip
-    cd preprocess-master
-    python setup.py install
+    pip install preprocess-master/
 ```
 Note that `preprocess.py` version 1.2 depends on [python-future](http://python-future.org). If you have `pip` installed, `python-future` is easily installed by
 


### PR DESCRIPTION
Unzipping (I tried both `UnZip 6.00 of 20 April 2009, by Info-ZIP.  Maintained by C. Spieler` and `UnZip 6.00 of 20 April 2009, by Debian. Original by Info-ZIP`) gives you `preprocess-master` directory instead of just `preprocess`.
Also `python setup.py install` is not worked for me (you can try it for yourself at https://colab.research.google.com/), it did not place the package in the right place so it can not be imported (honestly, I am lazy to find where it must be placed and why it's not working, because I tried `pip` and it works like a charm).